### PR TITLE
feat: adding auth interfaces and hover in login

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Body } from "../../../components/common/Typography";
+import Link from "next/link";
 
 const LoginPage = () => {
   const [email, setEmail] = useState("");
@@ -55,19 +56,18 @@ const LoginPage = () => {
           </div>
 
           <div className="text-right">
-            <Body
-              as="a"
-              href="#"
-              className="font-bold text-white hover:text-[hsl(var(--accent))] transition-colors"
-            >
-              ¿Olvidaste tu contraseña?
-            </Body>
+            <Link
+              href="/forgot-password"
+              className="font-bold text-white hover:underline underline-offset-4 decoration-[hsl(var(--accent))] hover:text-[hsl(var(--accent))] transition-colors">
+              <Body as="span">
+                ¿Olvidaste tu contraseña?
+              </Body>
+            </Link>
           </div>
 
           <button
             type="submit"
-            className="w-full h-11 bg-[hsl(var(--accent))] rounded-full flex items-center justify-center px-4 py-2.5 hover:bg-opacity-90 transition-all focus:outline-none focus:ring-2 focus:ring-[hsl(var(--accent))] focus:ring-offset-2 focus:ring-offset-[hsl(var(--dark))]"
-          >
+            className="w-full h-11 bg-[hsl(var(--accent))] rounded-full flex items-center justify-center px-4 py-2.5 hover:bg-opacity-90 transition-all focus:outline-none focus:ring-2 focus:ring-[hsl(var(--accent))] focus:ring-offset-2 focus:ring-offset-[hsl(var(--dark))]">
             <Body className="font-bold text-base text-white">
               Iniciar sesión
             </Body>

--- a/src/app/(auth)/password-reset-success/page.tsx
+++ b/src/app/(auth)/password-reset-success/page.tsx
@@ -31,7 +31,7 @@ const PasswordResetSuccessPage = () => {
                             <path
                                 fillRule="evenodd"
                                 clipRule="evenodd"
-                                d="M4.755 10.059a7.5 7.5 0 0 1 12.548-3.364l1.903 1.903h-3.183a.75.75 0 1 0 0 1.5h4.992a.75.75 0 0 0 .75-.75V4.356a.75.75 0 0 0-1.5 0v3.18l-1.9-1.9A9 9 0 0 0 3.306 9.67a.75.75 0 1 0 1.45.388Zm15.408 3.352a.75.75 0 0 0-.919.53 7.5 7.5 0 0 1-12.548 3.364l-1.902-1.903h3.183a.75.75 0 0 0 0-1.5H2.984a.75.75 0 0 0-.75.75v4.992a.75.75 0 0 0 1.5 0v-3.18l1.9 1.9a9 9 0 0 0 15.059-4.035.75.75 0 0 0-.53-.918Z"/>
+                                d="M4.755 10.059a7.5 7.5 0 0 1 12.548-3.364l1.903 1.903h-3.183a.75.75 0 1 0 0 1.5h4.992a.75.75 0 0 0 .75-.75V4.356a.75.75 0 0 0-1.5 0v3.18l-1.9-1.9A9 9 0 0 0 3.306 9.67a.75.75 0 1 0 1.45.388Zm15.408 3.352a.75.75 0 0 0-.919.53 7.5 7.5 0 0 1-12.548 3.364l-1.902-1.903h3.183a.75.75 0 0 0 0-1.5H2.984a.75.75 0 0 0-.75.75v4.992a.75.75 0 0 0 1.5 0v-3.18l1.9 1.9a9 9 0 0 0 15.059-4.035.75.75 0 0 0-.53-.918Z" />
                         </svg>
                     </div>
 
@@ -45,7 +45,7 @@ const PasswordResetSuccessPage = () => {
                         className="h-11 bg-[hsl(var(--accent))] rounded-full flex items-center justify-center px-4 py-2.5 hover:bg-opacity-90 transition-all focus:outline-none focus:ring-2 focus:ring-[hsl(var(--accent))] focus:ring-offset-2 focus:ring-offset-[hsl(var(--dark))] mx-auto"
                         aria-label="Solicitar código de restablecimiento de contraseña">
                         <Body className="font-bold text-base text-white">
-                            Solicitar código de restablecimiento
+                            Inicio de sesión
                         </Body>
                     </button>
 

--- a/src/app/(auth)/password-reset-success/page.tsx
+++ b/src/app/(auth)/password-reset-success/page.tsx
@@ -2,7 +2,7 @@
 
 import { Body } from "@/components/common/Typography";
 
-const ForgotPasswordPage = () => {
+const PasswordResetSuccessPage = () => {
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         // Lógica futura para envío de código
@@ -44,7 +44,7 @@ const ForgotPasswordPage = () => {
                         type="submit"
                         className="h-11 bg-[hsl(var(--accent))] rounded-full flex items-center justify-center px-4 py-2.5 hover:bg-opacity-90 transition-all focus:outline-none focus:ring-2 focus:ring-[hsl(var(--accent))] focus:ring-offset-2 focus:ring-offset-[hsl(var(--dark))] mx-auto"
                         aria-label="Solicitar código de restablecimiento de contraseña">
-                        <Body className="font-bold text-base text-white" href="#">
+                        <Body className="font-bold text-base text-white">
                             Solicitar código de restablecimiento
                         </Body>
                     </button>
@@ -55,4 +55,4 @@ const ForgotPasswordPage = () => {
     );
 };
 
-export default ForgotPasswordPage;
+export default PasswordResetSuccessPage;

--- a/src/app/(auth)/reset-password/[auth]/page.tsx
+++ b/src/app/(auth)/reset-password/[auth]/page.tsx
@@ -31,7 +31,7 @@ const PasswordResetPage = () => {
                             <path
                                 fillRule="evenodd"
                                 clipRule="evenodd"
-                                d="M4.755 10.059a7.5 7.5 0 0 1 12.548-3.364l1.903 1.903h-3.183a.75.75 0 1 0 0 1.5h4.992a.75.75 0 0 0 .75-.75V4.356a.75.75 0 0 0-1.5 0v3.18l-1.9-1.9A9 9 0 0 0 3.306 9.67a.75.75 0 1 0 1.45.388Zm15.408 3.352a.75.75 0 0 0-.919.53 7.5 7.5 0 0 1-12.548 3.364l-1.902-1.903h3.183a.75.75 0 0 0 0-1.5H2.984a.75.75 0 0 0-.75.75v4.992a.75.75 0 0 0 1.5 0v-3.18l1.9 1.9a9 9 0 0 0 15.059-4.035.75.75 0 0 0-.53-.918Z"/>
+                                d="M4.755 10.059a7.5 7.5 0 0 1 12.548-3.364l1.903 1.903h-3.183a.75.75 0 1 0 0 1.5h4.992a.75.75 0 0 0 .75-.75V4.356a.75.75 0 0 0-1.5 0v3.18l-1.9-1.9A9 9 0 0 0 3.306 9.67a.75.75 0 1 0 1.45.388Zm15.408 3.352a.75.75 0 0 0-.919.53 7.5 7.5 0 0 1-12.548 3.364l-1.902-1.903h3.183a.75.75 0 0 0 0-1.5H2.984a.75.75 0 0 0-.75.75v4.992a.75.75 0 0 0 1.5 0v-3.18l1.9 1.9a9 9 0 0 0 15.059-4.035.75.75 0 0 0-.53-.918Z" />
                         </svg>
                     </div>
 
@@ -45,7 +45,7 @@ const PasswordResetPage = () => {
                         className="h-11 bg-[hsl(var(--accent))] rounded-full flex items-center justify-center px-4 py-2.5 hover:bg-opacity-90 transition-all focus:outline-none focus:ring-2 focus:ring-[hsl(var(--accent))] focus:ring-offset-2 focus:ring-offset-[hsl(var(--dark))] mx-auto"
                         aria-label="Solicitar código de restablecimiento de contraseña">
                         <Body className="font-bold text-base text-white">
-                            Solicitar código de restablecimiento
+                            Restablecer contraseña
                         </Body>
                     </button>
 

--- a/src/app/(auth)/reset-password/[auth]/page.tsx
+++ b/src/app/(auth)/reset-password/[auth]/page.tsx
@@ -2,7 +2,7 @@
 
 import { Body } from "@/components/common/Typography";
 
-const ForgotPasswordPage = () => {
+const PasswordResetPage = () => {
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         // Lógica futura para envío de código
@@ -44,7 +44,7 @@ const ForgotPasswordPage = () => {
                         type="submit"
                         className="h-11 bg-[hsl(var(--accent))] rounded-full flex items-center justify-center px-4 py-2.5 hover:bg-opacity-90 transition-all focus:outline-none focus:ring-2 focus:ring-[hsl(var(--accent))] focus:ring-offset-2 focus:ring-offset-[hsl(var(--dark))] mx-auto"
                         aria-label="Solicitar código de restablecimiento de contraseña">
-                        <Body className="font-bold text-base text-white" href="#">
+                        <Body className="font-bold text-base text-white">
                             Solicitar código de restablecimiento
                         </Body>
                     </button>
@@ -55,4 +55,4 @@ const ForgotPasswordPage = () => {
     );
 };
 
-export default ForgotPasswordPage;
+export default PasswordResetPage;


### PR DESCRIPTION
📝 **1. ¿Qué hace este cambio?**
This update adds the password recovery flow:

- "Reset Password" interface
- "Request Reset Password" interface
- "Password Successfully Reset" interface
Additionally, a hover effect was added to the "Forgot your password?" link to improve the user experience.

🎯 **2. ¿Por qué se hace este cambio?**
To complete the password recovery functionality and provide users with a smooth and accessible way to recover their accounts. The hover effect enhances visual feedback and accessibility.

🔍 **3. ¿Cómo verificar el cambio?**

1. Go to /forgot-password and request a password reset.
2. Verify that the interface redirects to /password-reset-success.
3. Navigate manually to /reset-password/[auth] to test the reset form interface.
4. Hover over the "Forgot your password?" link and check that the underline is styled and animated in pink.

✅ **4. Checklist de control**
- [x] Mi código funciona.
- [x] Hice una revisión rápida de mis propios cambios.
- [ ] La documentación relevante fue actualizada (si aplica).
