### PR TITLE
feat(payment): integrate payment methods fetching and add purchase su…

### DIFF
--- a/src/app/(shop)/cart/new-card/page.tsx
+++ b/src/app/(shop)/cart/new-card/page.tsx
@@ -9,6 +9,7 @@ import { Body, Subheading, BodySmall } from "@/components/atoms/Typography"
 import Button from "@/components/atoms/Button"
 import { useCart } from "@/contexts/CartContext"
 import Toast from "@/components/atoms/Toast"
+import PurchaseSummary from "@/components/organisms/PurchaseSummary"
 
 export default function AddCardPage() {
   const { getCartTotal } = useCart()
@@ -260,25 +261,7 @@ export default function AddCardPage() {
             </div>
 
             {/* Resumen */}
-            <div className="flex-1 w-full lg:w-auto">
-              <div className="p-6 bg-gray rounded-lg space-y-6">
-                <Subheading className="text-white">Resumen de la compra</Subheading>
-                <div className="h-px bg-white/20"></div>
-                <div className="flex justify-between items-center">
-                  <Body className="text-white text-xl">Producto</Body>
-                  <Body className="text-white text-xl">₡{subtotal.toLocaleString()}</Body>
-                </div>
-                <div className="flex justify-between items-center">
-                  <Body className="text-white text-xl">Envío</Body>
-                  <Body className="text-emerald-400 text-xl">Gratis</Body>
-                </div>
-                <div className="h-px bg-white/20"></div>
-                <div className="flex justify-between items-center">
-                  <Body className="text-white text-xl">Total</Body>
-                  <Subheading className="text-white text-xl">₡{total.toLocaleString()}</Subheading>
-                </div>
-              </div>
-            </div>
+          <PurchaseSummary subtotal={subtotal} total={total} />
           </div>
         </form>
       </div>

--- a/src/components/organisms/PurchaseSummary.tsx
+++ b/src/components/organisms/PurchaseSummary.tsx
@@ -1,0 +1,30 @@
+import { Body, Subheading } from "@/components/atoms/Typography";
+
+interface PurchaseSummaryProps {
+  subtotal: number;
+  total: number;
+}
+
+export default function PurchaseSummary({ subtotal, total }: PurchaseSummaryProps) {
+  return (
+    <div className="flex-1 w-full lg:w-auto">
+      <div className="p-6 bg-gray rounded-lg space-y-6">
+        <Subheading className="text-white">Resumen de la compra</Subheading>
+        <div className="h-px bg-white/20"></div>
+        <div className="flex justify-between items-center">
+          <Body className="text-white text-xl">Producto</Body>
+          <Body className="text-white text-xl">₡{subtotal.toLocaleString()}</Body>
+        </div>
+        <div className="flex justify-between items-center">
+          <Body className="text-white text-xl">Envío</Body>
+          <Body className="text-emerald-400 text-xl">Gratis</Body>
+        </div>
+        <div className="h-px bg-white/20"></div>
+        <div className="flex justify-between items-center">
+          <Body className="text-white text-xl">Total</Body>
+          <Subheading className="text-white text-xl">₡{total.toLocaleString()}</Subheading>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/services/payment/paymentOptions.ts
+++ b/src/services/payment/paymentOptions.ts
@@ -1,0 +1,29 @@
+import axios from "axios";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://ratacueva-api.onrender.com/api";
+
+export interface PaymentMethod {
+  _id: string;
+  type: string;
+  last4: string;
+  provider: string;
+  expiration: string;
+}
+
+export const getPaymentMethods = async (token: string): Promise<PaymentMethod[]> => {
+  try {
+    const config = {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    };
+
+    const response = await axios.get(`${API_URL}/users/payment-methods`, config);
+    
+    return response.data;
+
+  } catch (error) {
+    console.error("Error en paymentService.getPaymentMethods:", error);
+    throw error;
+  }
+};


### PR DESCRIPTION
📝 **1. What does this change do?**

This change extracts the purchase summary sidebar into a reusable component called `PurchaseSummary`. It is placed in `src/components/features/home/organisms/` and used in the `PaymentCardOptionsPage` to improve code organization and reusability.

🎯 **2. Why is this change being made?**

Componentizing the purchase summary improves maintainability, keeps the main page components cleaner, and allows reuse of the same logic and UI across multiple pages—such as the checkout or order confirmation views—without duplicating code.

🔍 **3. How to verify the change?**

1. Navigate to `/cart/payment-options` in the app.
2. You should see the purchase summary on the right side of the screen.
3. Confirm that the displayed subtotal and total are correct and formatted.
4. Ensure there are no UI or functionality regressions compared to the previous implementation.

✅ **4. Control checklist**

- [x] My code works.
- [x] I reviewed my own changes quickly.
- [x] Relevant documentation was updated (if applicable).
